### PR TITLE
Add docker compose and demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,12 @@
 # About htsget
-TODO: General description of htsget and why it is used in GDI
+The htsget protocol was selected for the `Data Reception` part of the GDI starter kit. Htsget enables for retrieval of files from the storage-and-interfaces archive. The specification of the protocol can be found [here](http://samtools.github.io/hts-specs/htsget.html).
 
 The repository contains the implemenation for the GDI starter kit, as well as a demo that can be used for understanding the product. Both solutions are packaged in the `docker-compose-htsget.yml` file. The major difference between the two implementations, is that the demo one can run on it's own, while the starter kit version requires some of the other GDI products in order to be functional.
 
 More details regarding that and the way to run the services can be found in the sections below. After deciding whether you would like to run the demo or starter kit version, follow the instructions on the respective section.
+
+**Important Note:** The current implementation of the htsget server **does not** enable for partial retrieval of a file. Therefore, only full files should be requested. This feature will be developed in future versions of the product
+
 
 ## HTSGET Configuration
 The configuration for the htsget server should rely in the a folder called `config-htsget`. Detailed description of the configuration options can be found in the [reference implementation repository](https://github.com/ga4gh/htsget-refserver#setup---native).
@@ -30,8 +33,8 @@ starter-kit-htsget$ docker compose -f docker-compose-htsget.yml up -d
 
 The logs for the two docker compose files can be accessed using the following commands for storage-and-interfaces and htsget respectively
 ```sh
-starter-kit-storage-and-interfaces$ docker logs -f docker-compose.yml -f
-starter-kit-htsget$ docker logs -f docker-compose-htsget.yml -f
+starter-kit-storage-and-interfaces$ docker compose logs -f docker-compose.yml -f
+starter-kit-htsget$ docker compose logs -f docker-compose-htsget.yml -f
 ```
 
 ## Access data with htsget
@@ -68,6 +71,7 @@ export HTS_ALLOW_UNENCRYPTED_AUTHORIZATION_HEADER="I understand the risks"
 export HTS_AUTH_LOCATION=token.txt
 ```
 TODO: Write instructions about adding the ca and the CURL_CA_BUNDLE export for tls
+
 2. Get the token from the OIDC endpoint by running
 ```sh
 curl -k -S https://dockerhost:8080/tokens | jq -r '.[0]' > token.txt
@@ -90,4 +94,6 @@ Once the script is finished and the data should be loaded.
 
 ### TODO: TLS configuration
 If the htsget is not run with storage and interfaces, remove the external volume from the docker compose
+
+
 

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ export HTS_AUTH_LOCATION=token.txt
 ```
 2. Get the token from the OIDC endpoint by running
 ```sh
-echo $(curl -k -S https://oidc:8080/tokens | jq '.[0]') > token.txt
+echo $(curl -k -S https://oidc:8080/tokens | jq -r '.[0]') > token.txt
 ```
 3. Finally get the file using
 ```sh

--- a/README.md
+++ b/README.md
@@ -1,30 +1,30 @@
 # About htsget
 The htsget protocol was selected for the `Data Reception` part of the GDI starter kit. Htsget enables for retrieval of files from the storage-and-interfaces archive. The specification of the protocol can be found [here](http://samtools.github.io/hts-specs/htsget.html).
 
-The repository contains the implemenation for the GDI starter kit, as well as a demo that can be used for understanding the product. Both solutions are packaged in the `docker-compose-htsget.yml` file. The major difference between the two implementations, is that the demo one can run on it's own, while the starter kit version requires some of the other GDI products in order to be functional.
+The repository contains the implementation for the GDI starter kit, as well as a demo that can be used for understanding the product. Both solutions are packaged in the `docker-compose-htsget.yml` file. The major difference between the two implementations, is that the demo one can run on it's own, while the starter kit version requires some of the other GDI products in order to be functional.
 
 More details regarding that and the way to run the services can be found in the sections below. After deciding whether you would like to run the demo or starter kit version, follow the instructions on the respective section.
 
 ## Disclaimer
-**Important Note:** The current implementation of the htsget server **does not** enable for partial retrieval of a file. Therefore, only full files should be requested. This feature will be developed in future versions of the product.
+**Important Note:** The current implementation of the htsget server **does not** allow for partial retrieval of a file. Therefore, only full files should be requested. This feature will be developed in future versions of the product.
 
 
 ## HTSGET Configuration
-The configuration for the htsget server should rely in the a folder called `config-htsget`. Detailed description of the configuration options can be found in the [reference implementation repository](https://github.com/ga4gh/htsget-refserver#setup---native).
+The configuration for the htsget server should exist in the folder called `config-htsget`. Detailed description of the configuration options can be found in the [reference implementation repository](https://github.com/ga4gh/htsget-refserver#setup---native).
 
 ## Running the services - Demo
-The demo profile of the docker compose, apart for the htsget server, contains a minio S3 that can be used as a storage backend and a data downloader that extracts a file in the `output` directory. Specifically, the S3 storage is being populated with the `NA12878.bam` file included in the `demo-data` folder of this repository. The data downloader is then setting the required environments variables and using the `samtools`, it makes a request to the `htsgest server`, which gives access to the requested file.
+The demo profile of the docker compose, apart for the htsget server, contains a minio S3 that can be used as a storage backend and a data downloader that extracts a file in the `output` directory. Specifically, the S3 storage is being populated with the `NA12878.bam` file included in the `demo-data` folder of this repository. The data downloader is then setting the required environment variables and using `samtools` to make a request to the `htsget server`, which gives access to the requested file.
 
-In order to run the demo version of the htsget, first follow the instructions about removing tls at the bottom of this file and then run
+In order to run the demo version of htsget, first follow the instructions about removing tls at the bottom of this file and then run
 ```sh
 docker compose -f docker-compose-htsget.yml --profile demo up
 ```
-Once all the services are finished, you should be able to find the `output` folder in the root of the repository, containing the `NA12878.bam` file.
+Once all the services have completed, you should be able to find the `output` folder in the root of the repository, containing the `NA12878.bam` file.
 
 If you are interested in the commands used for extracting the data, you can check the `data_downloader` section of the `docker-compose-htsget.yml` file.
 
 ## Running the services - Starter kit version
-The htsget product of the starter kit depends on the storage-and-interfaces. Specifically, the data served has to be ingested and stored in the archive included in the [storage-and-interfaces repository](https://github.com/GenomicDataInfrastructure/starter-kit-storage-and-interfaces). Therefore, in order to test the implementation, the two docker compose files (the storage-and-interfaces and the htsget) need to be started together, so that they share the same network and the different containers have access between them.
+The htsget product of the starter kit depends on the storage-and-interfaces product. Specifically, the data served has to be ingested and stored in the archive included in the [storage-and-interfaces repository](https://github.com/GenomicDataInfrastructure/starter-kit-storage-and-interfaces). Therefore, in order to test the implementation, the two docker compose files (the storage-and-interfaces and the htsget) need to be started together, so that they share the same network and the different containers have access between them.
 
 To start the services, start the individual docker compose environments from their respective root directories:
 ```sh
@@ -38,13 +38,13 @@ starter-kit-storage-and-interfaces$ docker compose -f docker-compose.yml logs -f
 starter-kit-htsget$ docker compose -f docker-compose-htsget.yml logs -f
 ```
 
-## Access data with htsget
+## Accessing data with htsget
 In order to test the htsget implementation, there needs to be some data ingested in the archive. In case you do not have any data to ingest, follow the procedure in the [add data section](#(optional)-add-data) before continuing in this section.
 
 ## Get file information
 **NOTE:** The sections below assume that data has been ingested in the archive.
 
-In order to make sure there exist files in the database and in order to get the ids needed in order to request one of them using htsget execute in the database container using
+In order to make sure files exist in the database and in order to get the ids needed in order to request one of them using htsget "execute" into the database container using:
 ```sh
 docker exec -it postgres bash
 ```
@@ -66,7 +66,7 @@ Start by executing in the samtools container with
 ```sh
 docker exec -it samtools-client bash
 ```
-1. The samtools client requires two variable to be exported, while a token containing the visas for the specified user should be provided. Set the two environment variables required using
+1. The samtools client requires two variables to be exported, and a token containing the visas for the specified user to be provided. Set the two environment variables required using
 ```sh
 export HTS_ALLOW_UNENCRYPTED_AUTHORIZATION_HEADER="I understand the risks"
 export HTS_AUTH_LOCATION=token.txt
@@ -78,7 +78,7 @@ export CURL_CA_BUNDLE=/shared/cert/ca.crt
 
 2. Get the token from the OIDC endpoint by running
 ```sh
-curl -k -S https://dockerhost:8080/tokens | jq -r '.[0]' > token.txt
+curl -k -s -S https://dockerhost:8080/tokens | jq -r '.[0]' > token.txt
 ```
 3. Finally get the file using
 ```sh
@@ -96,7 +96,7 @@ To run the container executing this script run
 ```sh
 starter-kit-storage-and-interfaces$ docker compose up data_loader
 ```
-Once the script is finished and the data should be loaded.
+Once the script has completed, the data should be loaded.
 
 
 ### TLS configuration

--- a/README.md
+++ b/README.md
@@ -82,11 +82,11 @@ curl -k -S https://dockerhost:8080/tokens | jq -r '.[0]' > token.txt
 ```
 3. Finally get the file using
 ```sh
-samtools view https://server:3000/reads/s3/<dataset_id>/<file_path>
+samtools view https://server:3000/reads/s3/<dataset_id>/<file_path_without.c4gh>
 ```
 where `dataset_id` and `file_path` are the results from the query to the database. For example, if you are using the data from the starter-kit-storage-and-interfaces repository, the command should be
 ```sh
-samtools view https://server:3000/reads/s3/EGAD74900000101/dummy_gdi.eu/NA12878.bam.c4gh
+samtools view https://server:3000/reads/s3/EGAD74900000101/dummy_gdi.eu/NA12878.bam
 ```
 
 ### (Optional) Add data

--- a/README.md
+++ b/README.md
@@ -1,1 +1,87 @@
-# starter-kit-htsget
+# About htsget
+TODO: General description of htsget and why it is used in GDI
+
+The repository contains the implemenation for the GDI starter kit, as well as a demo that can be used for understanding the product. Both solutions are packaged in the `docker-compose-htsget.yml` file. The major difference between the two implementations, is that the demo one can run on it's own, while the starter kit version requires some of the other GDI products in order to be functional. 
+
+More details regarding that and the way to run the services can be found in the sections below. After deciding whether you would like to run the demo or starter kit version, follow the instructions on the respective section.
+
+## HTSGET Configuration
+The configuration for the htsget server should rely in the a folder called `config-htsget`. Detailed description of the configuration options can be found in the [reference implementation repository](https://github.com/ga4gh/htsget-refserver#setup---native).
+
+## Running the services - Demo
+The demo profile of the docker compose, apart for the htsgetserver, contains a minio S3 that can be used as a storage backend and a data downloader that extracts a file in the `output` directory. Specifically, the S3 storage is being populated with the `NA12878.bam` file included in the `demo-data` folder of this repository. The data downloader is then setting the required environments variables and using the `samtools`, it makes a request to the `htsgest server`, which gives access to the requested file.
+
+In order to run the demo version of the htsget, run
+```sh
+docker compose -f docker-compose-htsget.yml --profile demo up
+```
+Once all the services are finished, you should be able to find the `output` folder in the root of the repository, containing the `NA12878.bam` file.
+
+If you are interested in the commands used for extracting the data, you can check the `data_downloader` section of the `docker-compose-htsget.yml` file.
+
+## Running the services - Starter kit version
+The htsget product of the starter kit depends on the storage-and-interfaces. Specifically, the data served has to be ingested and stored in the archive included in the [storage-and-interfaces repository](https://github.com/GenomicDataInfrastructure/starter-kit-storage-and-interfaces). Therefore, in order to test the implementation, the two docker compose files (the storage-and-interfaces and the htsget) need to be started together, so that they share the same network and the different containers have access between them.
+
+To start the services included in the docker compose files run
+```sh
+docker compose -f docker-compose.yml -f docker-compose-htsget.yml up -d
+```
+
+The logs for the two docker compose files can be accessed using the following commands for storage-and-interfaces and htsget respectively
+```sh
+docker logs -f docker-compose.yml -f
+docker logs -f docker-compose-htsget.yml -f
+```
+
+## Access data with htsget
+In order to test the htsget implementation, there needs to be some data ingested in the archive. In case you do not have any data to ingest, follow the procedure in the [add data section](#(optional)-add-data) before continuing in this section.
+
+## Get file information
+**NOTE:** The sections below assume that data has been ingested in the archive.
+
+In order to make sure there exist files in the database and in order to get the ids needed in order to request one of them using htsget execute in the database container using
+```sh
+docker exec -it postgres bash
+```
+Connect to the postgres database using
+```sh
+psql -h localhost -U postgres lega
+```
+with password `rootpass` and run the following query
+```sh
+select datasets.stable_id, files.stable_id, submission_file_path from sda.file_dataset join sda.files on file_id = files.id full join sda.datasets on file_dataset.id = sda.datasets.id;
+```
+You should be able to see some files and the dataset they have been added to. This information will be used in the next step in order to request one of the files.
+
+## Request a file with samtools
+
+Now that all the information regarding the ingested files is available, it should be possible to access a file using the htsget protocol. One way to do that, is using samtools, included in the `docker-compose-htsget.yml` file.
+
+Start by executing in the samtools container with
+```sh
+docker exec -it samtools-client bash
+```
+1. The samtools client requires two variable to be exported, while a token containing the visas for the specified user should be provided. Set the two environment variables required using
+```sh
+export HTS_ALLOW_UNENCRYPTED_AUTHORIZATION_HEADER="I understand the risks"
+export HTS_AUTH_LOCATION=token.txt
+```
+2. Get the token from the OIDC endpoint by running
+```sh
+echo $(curl -k -S https://oidc:8080/tokens | jq '.[0]') > token.txt
+```
+3. Finally get the file using
+```sh
+samtools view http://server:3000/reads/s3/<dataset_id>/<file_path>
+```
+where `dataset_id` and `file_path` are the results from the query to the database.
+
+### (Optional) Add data
+In case you do not have any data to ingest, there exists a [script](https://github.com/GenomicDataInfrastructure/starter-kit-storage-and-interfaces/blob/main/scripts/load_data.sh) that can load a very small sample dataset in the storage-and-interface repository, which can be executed using the same docker compose file. 
+
+To run the container executing this script run
+```sh
+docker compose up data_loader
+```
+Once the script is finished and the data should be loaded. 
+

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # About htsget
 TODO: General description of htsget and why it is used in GDI
 
-The repository contains the implemenation for the GDI starter kit, as well as a demo that can be used for understanding the product. Both solutions are packaged in the `docker-compose-htsget.yml` file. The major difference between the two implementations, is that the demo one can run on it's own, while the starter kit version requires some of the other GDI products in order to be functional. 
+The repository contains the implemenation for the GDI starter kit, as well as a demo that can be used for understanding the product. Both solutions are packaged in the `docker-compose-htsget.yml` file. The major difference between the two implementations, is that the demo one can run on it's own, while the starter kit version requires some of the other GDI products in order to be functional.
 
 More details regarding that and the way to run the services can be found in the sections below. After deciding whether you would like to run the demo or starter kit version, follow the instructions on the respective section.
 
@@ -22,15 +22,16 @@ If you are interested in the commands used for extracting the data, you can chec
 ## Running the services - Starter kit version
 The htsget product of the starter kit depends on the storage-and-interfaces. Specifically, the data served has to be ingested and stored in the archive included in the [storage-and-interfaces repository](https://github.com/GenomicDataInfrastructure/starter-kit-storage-and-interfaces). Therefore, in order to test the implementation, the two docker compose files (the storage-and-interfaces and the htsget) need to be started together, so that they share the same network and the different containers have access between them.
 
-To start the services included in the docker compose files run
+To start the services, start the individual docker compose environments from their respective root directories:
 ```sh
-docker compose -f docker-compose.yml -f docker-compose-htsget.yml up -d
+starter-kit-storage-and-interfaces$ docker compose up -d
+starter-kit-htsget$ docker compose -f docker-compose-htsget.yml up -d
 ```
 
 The logs for the two docker compose files can be accessed using the following commands for storage-and-interfaces and htsget respectively
 ```sh
-docker logs -f docker-compose.yml -f
-docker logs -f docker-compose-htsget.yml -f
+starter-kit-storage-and-interfaces$ docker logs -f docker-compose.yml -f
+starter-kit-htsget$ docker logs -f docker-compose-htsget.yml -f
 ```
 
 ## Access data with htsget
@@ -68,20 +69,20 @@ export HTS_AUTH_LOCATION=token.txt
 ```
 2. Get the token from the OIDC endpoint by running
 ```sh
-echo $(curl -k -S https://oidc:8080/tokens | jq -r '.[0]') > token.txt
+curl -k -S https://dockerhost:8080/tokens | jq -r '.[0]' > token.txt
 ```
 3. Finally get the file using
 ```sh
-samtools view http://server:3000/reads/s3/<dataset_id>/<file_path>
+samtools view http://server:3000/reads/s3/<dataset_id>/<file_path_without_.c4gh>
 ```
 where `dataset_id` and `file_path` are the results from the query to the database.
 
 ### (Optional) Add data
-In case you do not have any data to ingest, there exists a [script](https://github.com/GenomicDataInfrastructure/starter-kit-storage-and-interfaces/blob/main/scripts/load_data.sh) that can load a very small sample dataset in the storage-and-interface repository, which can be executed using the same docker compose file. 
+In case you do not have any data to ingest, there exists a [script](https://github.com/GenomicDataInfrastructure/starter-kit-storage-and-interfaces/blob/main/scripts/load_data.sh) that can load a very small sample dataset in the storage-and-interface repository, which can be executed using the same docker compose file.
 
 To run the container executing this script run
 ```sh
 docker compose up data_loader
 ```
-Once the script is finished and the data should be loaded. 
+Once the script is finished and the data should be loaded.
 

--- a/README.md
+++ b/README.md
@@ -67,13 +67,14 @@ docker exec -it samtools-client bash
 export HTS_ALLOW_UNENCRYPTED_AUTHORIZATION_HEADER="I understand the risks"
 export HTS_AUTH_LOCATION=token.txt
 ```
+TODO: Write instructions about adding the ca and the CURL_CA_BUNDLE export for tls
 2. Get the token from the OIDC endpoint by running
 ```sh
 curl -k -S https://dockerhost:8080/tokens | jq -r '.[0]' > token.txt
 ```
 3. Finally get the file using
 ```sh
-samtools view http://server:3000/reads/s3/<dataset_id>/<file_path_without_.c4gh>
+samtools view http://server:3000/reads/s3/<dataset_id>/<file_path>
 ```
 where `dataset_id` and `file_path` are the results from the query to the database.
 
@@ -85,4 +86,8 @@ To run the container executing this script run
 docker compose up data_loader
 ```
 Once the script is finished and the data should be loaded.
+
+
+### TODO: TLS configuration
+If the htsget is not run with storage and interfaces, remove the external volume from the docker compose
 

--- a/config-htsget/config-no-tls.json
+++ b/config-htsget/config-no-tls.json
@@ -3,9 +3,7 @@
       "props": {
         "port": "3000",
         "host": "http://localhost/",
-        "logLevel": "debug",
-        "serverCert": "/shared/cert/server.crt",
-        "serverKey": "/shared/cert/server.key"
+        "logLevel": "debug"
       },
       "reads": {
         "enabled": true,
@@ -26,7 +24,7 @@
         }
       },
       "variants": {
-        "enabled": true,
+        "enabled": false,
         "serviceInfo": {
           "id": "org.ga4gh.htsget-reference.variants"
         }

--- a/config-htsget/config-tls.json
+++ b/config-htsget/config-tls.json
@@ -1,0 +1,35 @@
+{
+    "htsgetConfig": {
+      "props": {
+        "port": "3000",
+        "host": "http://localhost/",
+        "logLevel": "debug",
+        "serverCert": "/shared/cert/server.crt",
+        "serverKey": "/shared/cert/server.key"
+      },
+      "reads": {
+        "enabled": true,
+        "dataSourceRegistry": {
+          "sources": [
+            {
+              "pattern": "^s3/(?P<accession>.*)$",
+              "path": "http://dockerhost:8443/s3/{accession}"
+            },
+            {
+              "pattern": "^pub/(?P<accession>.*)$",
+              "path": "http://s3public:9000/inbox/{accession}"
+            }
+          ]
+        },
+        "serviceInfo": {
+          "id": "org.ga4gh.htsget-reference.reads"
+        }
+      },
+      "variants": {
+        "enabled": true,
+        "serviceInfo": {
+          "id": "org.ga4gh.htsget-reference.variants"
+        }
+      }
+    }
+  }

--- a/config-htsget/config.json
+++ b/config-htsget/config.json
@@ -3,16 +3,12 @@
     "props": {
       "port": "3000",
       "host": "http://localhost/",
-      "logFile": "/logs/htsget.log"
+      "logLevel": "debug"
     },
     "reads": {
       "enabled": true,
       "dataSourceRegistry": {
         "sources": [
-          {
-            "pattern": "^local/(?P<accession>.*)$",
-            "path": "/usr/src/app/data/gcp/gatk-test-data/{accession}.bam"
-          },
           {
             "pattern": "^s3/(?P<accession>.*)$",
             "path": "http://dockerhost:8443/s3/{accession}"

--- a/config-htsget/config.json
+++ b/config-htsget/config.json
@@ -15,7 +15,7 @@
           },
           {
             "pattern": "^s3/(?P<accession>.*)$",
-            "path": "http://download:8443/s3/{accession}"
+            "path": "http://dockerhost:8443/s3/{accession}"
           },
           {
             "pattern": "^pub/(?P<accession>.*)$",

--- a/config-htsget/config.json
+++ b/config-htsget/config.json
@@ -3,7 +3,9 @@
     "props": {
       "port": "3000",
       "host": "http://localhost/",
-      "logLevel": "debug"
+      "logLevel": "debug",
+      "serverCert": "/shared/cert/server.crt",
+      "serverKey": "/shared/cert/server.key"
     },
     "reads": {
       "enabled": true,
@@ -24,7 +26,7 @@
       }
     },
     "variants": {
-      "enabled": true,
+      "enabled": false,
       "serviceInfo": {
         "id": "org.ga4gh.htsget-reference.variants"
       }

--- a/config-htsget/config.json
+++ b/config-htsget/config.json
@@ -1,0 +1,37 @@
+{
+  "htsgetConfig": {
+    "props": {
+      "port": "3000",
+      "host": "http://localhost/",
+      "logFile": "/logs/htsget.log"
+    },
+    "reads": {
+      "enabled": true,
+      "dataSourceRegistry": {
+        "sources": [
+          {
+            "pattern": "^local/(?P<accession>.*)$",
+            "path": "/usr/src/app/data/gcp/gatk-test-data/{accession}.bam"
+          },
+          {
+            "pattern": "^s3/(?P<accession>.*)$",
+            "path": "http://download:8443/s3/{accession}"
+          },
+          {
+            "pattern": "^pub/(?P<accession>.*)$",
+            "path": "http://s3public:9000/inbox/{accession}"
+          }
+        ]
+      },
+      "serviceInfo": {
+        "id": "org.ga4gh.htsget-reference.reads"
+      }
+    },
+    "variants": {
+      "enabled": true,
+      "serviceInfo": {
+        "id": "org.ga4gh.htsget-reference.variants"
+      }
+    }
+  }
+}

--- a/docker-compose-htsget.yml
+++ b/docker-compose-htsget.yml
@@ -102,7 +102,7 @@ services:
       /bin/sh -c "
       sleep 10;
       /usr/bin/mc -q config host add s3 http://s3public:9000 access secretkey;
-      /usr/bin/mc -q mb s3/inbox || true;
+      /usr/bin/mc -q mb s3/inbox;
       /usr/bin/mc anonymous set public s3/inbox;
       /usr/bin/mc cp /data/NA12878.bam s3/inbox/NA12878.bam;
       exit 0;

--- a/docker-compose-htsget.yml
+++ b/docker-compose-htsget.yml
@@ -12,9 +12,10 @@ services:
     ports:
       - 3000:3000
     volumes:
-      # If you want to start the docker compose without tls, remove the line below
-      # and the relevant configuration from the config-htsget/config.json file,
-      # which are the lines for serverCert and serverKey
+      # If you want to start the docker compose without tls, remove the line below,
+      # remove the starter-kit-storage-and-interfaces_shared volume from the bottom
+      # of the file and the relevant configuration from the config-htsget/config.json 
+      # file, which are the lines for serverCert and serverKey.
       # The TLS version assumes that this compose file is running along with the
       # storage and interfaces.
       # If you want to run the htsget with TLS but without the storage and interfaces,
@@ -51,6 +52,8 @@ services:
       - -c 
       - apt update; apt install -y curl jq;
         while true; do sleep 250; done
+    volumes:
+      - starter-kit-storage-and-interfaces_shared:/shared
     extra_hosts:
     - dockerhost:host-gateway
   

--- a/docker-compose-htsget.yml
+++ b/docker-compose-htsget.yml
@@ -16,6 +16,8 @@ services:
       - ./scripts/certs:/usr/local/share/ca-certificates
       - ./config-htsget:/config
       - ./logs:/logs
+    extra_hosts:
+    - dockerhost:host-gateway
 
   client:
     image: python:3.11-slim
@@ -29,6 +31,8 @@ services:
       - apt update; apt install -y curl;
         if ! which htsget >/dev/null; then pip install htsget; fi;
         while true; do sleep 250; done
+    extra_hosts:
+    - dockerhost:host-gateway
   
   samtools:
     image: staphb/samtools:1.17
@@ -41,6 +45,8 @@ services:
       - -c 
       - apt update; apt install -y curl jq;
         while true; do sleep 250; done
+    extra_hosts:
+    - dockerhost:host-gateway
   
   s3public:
     profiles: ["demo"]
@@ -112,10 +118,11 @@ services:
         export HTS_AUTH_LOCATION=token.txt;
         echo "some-token" > token.txt;
         apt update; apt install -y curl jq;
-        samtools view http://server:3000/reads/pub/NA12878.bam > NA12878.bam;
+        samtools view -b http://server:3000/reads/pub/NA12878.bam > NA12878.bam;
        exit 0;
     volumes:
       - ./output:/data
+
 volumes:
   s3pubdata:
 

--- a/docker-compose-htsget.yml
+++ b/docker-compose-htsget.yml
@@ -1,0 +1,124 @@
+services:
+  server:
+    image: harbor.nbis.se/gdi/htsget-refserver:dev
+    container_name: htsget-server
+    command:
+      - /usr/src/app/htsget-refserver
+      - -config
+      - /config/config.json
+    networks:
+      - public
+      - secure
+    ports:
+      - 3000:3000
+    volumes:
+      #- certs:/etc/ssl/certs
+      - ./scripts/certs:/usr/local/share/ca-certificates
+      - ./config-htsget:/config
+      - ./logs:/logs
+
+  client:
+    image: python:3.11-slim
+    container_name: htsget-client
+    networks:
+      - public
+      - secure
+    command:
+      - /bin/bash
+      - -c
+      - apt update; apt install -y curl;
+        if ! which htsget >/dev/null; then pip install htsget; fi;
+        while true; do sleep 250; done
+  
+  samtools:
+    image: staphb/samtools:1.17
+    container_name: samtools-client
+    networks:
+      - public
+      - secure
+    command:
+      - /bin/bash
+      - -c 
+      - apt update; apt install -y curl jq;
+        while true; do sleep 250; done
+  
+  s3public:
+    profiles: ["demo"]
+    command: server /data --console-address ":9001"
+    container_name: s3public
+    depends_on:
+      server:
+        condition: service_started
+    environment:
+      - MINIO_ROOT_USER=access
+      - MINIO_ROOT_PASSWORD=secretkey
+      - MINIO_SERVER_URL=http://127.0.0.1:9000
+    healthcheck:
+      test:
+        [
+          "CMD",
+          "curl",
+          "-fq",
+          "http://localhost:9000/minio/health/live"
+        ]
+      interval: 5s
+      timeout: 20s
+      retries: 3
+    image: minio/minio:RELEASE.2023-02-10T18-48-39Z
+    networks:
+      - secure
+    ports:
+      - "9003:9000"
+      - "9004:9001"
+    restart: always
+    volumes:
+      - s3pubdata:/data
+  
+  createbucket:
+    profiles: ["demo"]
+    image: minio/mc
+    container_name: mc-s3
+    depends_on:
+      s3public:
+        condition: service_started
+    networks:
+      - secure
+    entrypoint: >
+      /bin/sh -c "
+      sleep 10;
+      /usr/bin/mc -q config host add s3 http://s3public:9000 access secretkey;
+      /usr/bin/mc -q mb s3/inbox || true;
+      /usr/bin/mc anonymous set public s3/inbox;
+      /usr/bin/mc cp /data/NA12878.bam s3/inbox/NA12878.bam;
+      exit 0;
+      "
+    volumes:
+      - ./demo-data:/data
+    
+  data_downloader:
+    profiles: ["demo"]
+    image: staphb/samtools:1.17
+    container_name: data-downloader
+    depends_on:
+      createbucket:
+        condition: service_completed_successfully
+    networks:
+      - public
+      - secure
+    command:
+      - /bin/bash
+      - -c 
+      - export HTS_ALLOW_UNENCRYPTED_AUTHORIZATION_HEADER="I understand the risks";
+        export HTS_AUTH_LOCATION=token.txt;
+        echo "some-token" > token.txt;
+        apt update; apt install -y curl jq;
+        samtools view http://server:3000/reads/pub/NA12878.bam > NA12878.bam;
+       exit 0;
+    volumes:
+      - ./output:/data
+volumes:
+  s3pubdata:
+
+networks:
+  public:
+  secure:

--- a/docker-compose-htsget.yml
+++ b/docker-compose-htsget.yml
@@ -1,6 +1,6 @@
 services:
   server:
-    image: harbor.nbis.se/gdi/htsget-refserver:dev
+    image: harbor.nbis.se/gdi/htsget-refserver:0.1.0
     container_name: htsget-server
     command:
       - /usr/src/app/htsget-refserver
@@ -12,8 +12,14 @@ services:
     ports:
       - 3000:3000
     volumes:
-      #- certs:/etc/ssl/certs
-      - ./scripts/certs:/usr/local/share/ca-certificates
+      # If you want to start the docker compose without tls, remove the line below
+      # and the relevant configuration from the config-htsget/config.json file,
+      # which are the lines for serverCert and serverKey
+      # The TLS version assumes that this compose file is running along with the
+      # storage and interfaces.
+      # If you want to run the htsget with TLS but without the storage and interfaces,
+      # add the certificates in the volume below
+      - starter-kit-storage-and-interfaces_shared:/shared
       - ./config-htsget:/config
       - ./logs:/logs
     extra_hosts:
@@ -125,6 +131,8 @@ services:
 
 volumes:
   s3pubdata:
+  starter-kit-storage-and-interfaces_shared:
+    external: true
 
 networks:
   public:


### PR DESCRIPTION
This pull requests creates a first version of the docker compose that will be used in the GDI starter kit. It contains a 
- docker compose file with the versions required for the htsget server to be able to request files from the `sda-download` service, using an authentication token (JWT).
- a profile for running a minio S3 storage, to demo the file access through a public bucket
- documentation about the usage of the compose files and general information about the htsget


Closes: #2 
